### PR TITLE
添加python版本和tk是否可用判断

### DIFF
--- a/JavSP.py
+++ b/JavSP.py
@@ -20,6 +20,14 @@ from core.print import TqdmOut
 from core.baidu_aip import aip_crop_poster
 
 
+# python版本检查
+import platform 
+version = float(platform.python_version[:3])
+if version < 3.8:
+    print('Python版本需要大于等于3.8')
+    exit(1)
+
+
 # 将StreamHandler的stream修改为TqdmOut，以与Tqdm协同工作
 root_logger = logging.getLogger()
 for handler in root_logger.handlers:

--- a/core/func.py
+++ b/core/func.py
@@ -11,8 +11,14 @@ import logging
 import subprocess
 from datetime import datetime
 from packaging import version
-from tkinter import filedialog, Tk
 from colorama import Fore, Style
+
+# 判断系统是否可以使用tk
+USEGUI = True
+try:
+    from tkinter import filedialog, Tk
+except:
+    USEGUI = False
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from web.base import *
@@ -29,6 +35,9 @@ logger = logging.getLogger(__name__)
 
 def select_folder(default_dir=''):
     """使用文件对话框提示用户选择一个文件夹"""
+    if not USEGUI:
+        logger.error("无法打开窗口，请通过命令行的方式输入扫描路径")
+        exit(1)
     window = Tk()
     window.withdraw()
     window.iconbitmap(mei_path('image/JavSP.ico'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ pefile==2019.4.18
 Pillow==9.0.1
 pretty-errors==1.2.19
 pycryptodome==3.10.1
-pywin32==303
 PySocks==1.7.1
-pywin32-ctypes==0.2.0
 requests==2.25.1
 tqdm==4.59.0
 urllib3==1.26.5
+pywin32==303
+pywin32-ctypes==0.2.0


### PR DESCRIPTION
1、代码中使用了位置形参，位置形参仅支持python3.8及以上版本。故增加python版本判断代码，如果python版本低于3.8则报错退出
2、Linux服务器中无图形界面，无法使用tk，故加入USEGUI这个flag，使程序无法import tkinter时也能通过命令行和配置文件的方式，指定扫描路径使用。
3、Linux下不存在pywin32和pywin32-ctypes库，故将requestments.txt文件中，这两个库的安装顺序放到最后。经测试，linux不安装这两个库代码也是可以运行并爬取到结果。