### PR TITLE
Bugfix

### DIFF
--- a/JavSP.py
+++ b/JavSP.py
@@ -250,11 +250,12 @@ def generate_names(movie: Movie):
     if cfg.NamingRule.enable_file_move is False:
         # 如果不整理文件，则保存抓取的数据到当前目录
         movie.save_dir = os.path.dirname(movie.files[0])
-        movie.basename = os.path.basename(movie.files[0])
-        # ext = os.path.splitext(movie.files[0])[1]
-        movie.nfo_file = os.path.join(movie.save_dir, f'{movie.basename}.nfo')
-        movie.fanart_file = os.path.join(movie.save_dir, f'{movie.basename}-fanart.nfo')
-        movie.poster_file = os.path.join(movie.save_dir, f'{movie.basename}-poster.jpg')
+        ext = os.path.splitext(movie.files[0])[1]
+        movie.basename = os.path.spli(movie.files[0])
+        file_basename = movie.basename.replace(ext, '')
+        movie.nfo_file = os.path.join(movie.save_dir, f'{file_basename}.nfo')
+        movie.fanart_file = os.path.join(movie.save_dir, f'{file_basename}-fanart.nfo')
+        movie.poster_file = os.path.join(movie.save_dir, f'{file_basename}-poster.jpg')
         return
     # 使用字典填充模板，生成相关文件的路径（多分片影片要考虑CD-x部分）
     cdx = '' if len(movie.files) <= 1 else '-CD1'
@@ -328,7 +329,9 @@ def postStep_MultiMoviePoster(movie: Movie):
             cdx_poster = os.path.join(movie.save_dir, f'{movie.basename}-CD{i}-poster.jpg')
         else:
             basename = os.path.basename(movie.files[i])
-            cdx_poster = os.path.join(movie.save_dir, f'{basename}-poster.jpg')
+            ext = os.path.splitext(movie.files[i])[1]
+            file_basename = basename.replace(ext, '')
+            cdx_poster = os.path.join(movie.save_dir, f'{file_basename}-poster.jpg')
         copyfile(movie.poster_file, cdx_poster)
 
 
@@ -453,10 +456,12 @@ def RunNormalMode(all_movies):
             check_step(True)
 
             inner_bar.set_description('移动影片文件')
-            # movie.rename_files()
-            # check_step(True)
-
-            # logger.info(f'整理完成，相关文件已保存到: {movie.save_dir}\n')
+            if cfg.NamingRule.enable_file_move:
+                movie.rename_files()
+                check_step(True)
+                logger.info(f'整理完成，相关文件已保存到: {movie.save_dir}\n')
+            else:
+                logger.info(f'数据抓取完成，相关文件已保存到: {movie.nfo_file}\n')
         except Exception as e:
             logger.debug(e, exc_info=True)
             logger.error(f'整理失败: {e}')

--- a/JavSP.py
+++ b/JavSP.py
@@ -250,8 +250,8 @@ def generate_names(movie: Movie):
     if cfg.NamingRule.enable_file_move is False:
         # 如果不整理文件，则保存抓取的数据到当前目录
         movie.save_dir = os.path.dirname(movie.files[0])
-        ext = os.path.splitext(movie.files[0])[1]
-        movie.basename = os.path.spli(movie.files[0])
+        movie.basename = os.path.basename(movie.files[0])
+        ext = os.path.splitext(movie.basename)[1]
         file_basename = movie.basename.replace(ext, '')
         movie.nfo_file = os.path.join(movie.save_dir, f'{file_basename}.nfo')
         movie.fanart_file = os.path.join(movie.save_dir, f'{file_basename}-fanart.nfo')

--- a/core/config.ini
+++ b/core/config.ini
@@ -14,7 +14,7 @@ scan_dir =
 ## 哪些后缀的文件应当视为影片？
 media_ext = 3gp;avi;f4v;flv;iso;m2ts;m4v;mkv;mov;mp4;mpeg;rm;rmvb;ts;vob;webm;wmv
 # 扫描影片文件时忽略指定的文件夹（以.开头的文件夹不需要设置也会被忽略）
-ignore_folder = #整理完成;不要扫描
+ignore_folder = #recycle;#整理完成;不要扫描
 
 [Network]
 # 是否启用代理
@@ -58,6 +58,8 @@ javlib = https://www.g60y.com
 # save_dir, nfo_title和filename中可以使用变量来引用影片的数据，支持的变量列表见下面的地址:
 # https://github.com/Yuukiy/JavSP/wiki/NamingRule-%7C-%E5%91%BD%E5%90%8D%E8%A7%84%E5%88%99
 [NamingRule]
+# 是否开启文件整理功能，如果不开启则会在视频文件同级目录保存抓取的信息。默认关闭，方便做种
+enable_file_move = no
 # 设置媒体服务器类型
 media_servers = jellyfin
 # 整理后的影片和封面等文件的保存位置

--- a/core/config.py
+++ b/core/config.py
@@ -250,6 +250,7 @@ def norm_boolean(cfg: Config):
             ('Crawler', 'respect_site_avid'),
             ('Crawler', 'title__remove_actor'),
             ('Crawler', 'title__chinese_first'),
+            ('NamingRule', 'enable_file_move'),
             ('Picture', 'use_big_cover'),
             ('Picture', 'use_ai_crop'),
             ('NFO', 'add_genre_to_tag'),

--- a/core/file.py
+++ b/core/file.py
@@ -27,10 +27,22 @@ def scan_movies(root: str) -> List[Movie]:
     # 扫描所有影片文件并获取它们的番号
     dic = {}    # avid: [abspath1, abspath2...]
     for dirpath, dirnames, filenames in os.walk(root):
-        for name in dirnames:
-            if name.startswith('.') or name in cfg.File.ignore_folder:
-                dirnames.remove(name)
+        if dirpath.startswith('.'):
+            # 特殊文件夹排除
+            logger.debug(f"文件夹[{dirpath}]已被忽略11111。")
+            continue
+        dir_is_ignore = False
+        for cif in cfg.File.ignore_folder:
+            # 根目录被忽略或者是被忽略目录的子目录都排除
+            if dirpath == cif or dirpath.find(cif) >= 0:
+                dir_is_ignore = True
+                break
+        if dir_is_ignore is True:
+            logger.debug(f"文件夹[{dirpath}]已被忽略222222。")
+            continue
+        logger.debug(f"文件夹[{dirpath}]没有被忽略。")
         for file in filenames:
+            logger.debug(f"文件[{file}]开始处理")
             ext = os.path.splitext(file)[1].lower()
             if ext in cfg.File.media_ext:
                 fullpath = os.path.join(dirpath, file)

--- a/core/nfo.py
+++ b/core/nfo.py
@@ -72,7 +72,7 @@ def write_nfo(info: MovieInfo, nfo_file):
         nfo.append(E.set(E.name(info.serial)))
 
     if info.director:
-        nfo.append(E.directr(info.director))
+        nfo.append(E.director(info.director))
 
     # 发行日期。文档中关于'year'字段的说明: Do not use. Use <premiered> instead
     if info.publish_date:

--- a/web/airav.py
+++ b/web/airav.py
@@ -4,6 +4,7 @@ import re
 import sys
 import logging
 from html import unescape
+from core.func import remove_trail_actor_in_title
 
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -107,6 +108,20 @@ def parse_data(movie: MovieInfo):
         if not any([movie.title, movie.plot, movie.genre]):
             break
 
+def parse_clean_data(movie: MovieInfo):
+    """解析指定番号的影片数据并进行清洗"""
+    try:
+        parse_data(movie)
+    except SiteBlocked:
+        raise
+        logger.error('JavDB: 可能触发了反爬虫机制，请稍后再试')
+    # 将此功能放在各个抓取器以保持数据的一致，避免影响转换（写入nfo时的信息来自多个抓取器的汇总，数据来源一致性不好）
+    if cfg.Crawler.title__remove_actor:
+        new_title = remove_trail_actor_in_title(movie.title, movie.actress)
+        if new_title != movie.title:
+            movie.ori_title = movie.title
+            movie.title = new_title
+
 
 if __name__ == "__main__":
     import pretty_errors
@@ -115,7 +130,7 @@ if __name__ == "__main__":
 
     movie = MovieInfo('DSAD-938')
     try:
-        parse_data(movie)
+        parse_clean_data(movie)
         print(movie)
     except CrawlerError as e:
         logger.error(e, exc_info=1)

--- a/web/avsox.py
+++ b/web/avsox.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import logging
+from core.func import remove_trail_actor_in_title
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from web.base import get_html
@@ -53,6 +54,20 @@ def parse_data(movie: MovieInfo):
     movie.genre = genre
     movie.actress = actress
 
+def parse_clean_data(movie: MovieInfo):
+    """解析指定番号的影片数据并进行清洗"""
+    try:
+        parse_data(movie)
+    except SiteBlocked:
+        raise
+        logger.error('JavDB: 可能触发了反爬虫机制，请稍后再试')
+    # 将此功能放在各个抓取器以保持数据的一致，避免影响转换（写入nfo时的信息来自多个抓取器的汇总，数据来源一致性不好）
+    if cfg.Crawler.title__remove_actor:
+        new_title = remove_trail_actor_in_title(movie.title, movie.actress)
+        if new_title != movie.title:
+            movie.ori_title = movie.title
+            movie.title = new_title
+
 
 if __name__ == "__main__":
     import pretty_errors
@@ -61,7 +76,7 @@ if __name__ == "__main__":
 
     movie = MovieInfo('130614-KEIKO')
     try:
-        parse_data(movie)
+        parse_clean_data(movie)
         print(movie)
     except CrawlerError as e:
         logger.error(e, exc_info=1)

--- a/web/fc2.py
+++ b/web/fc2.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import logging
+from core.func import remove_trail_actor_in_title
 
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -108,6 +109,19 @@ def parse_data(movie: MovieInfo):
     else:
         movie.cover = thumb_pic
 
+def parse_clean_data(movie: MovieInfo):
+    """解析指定番号的影片数据并进行清洗"""
+    try:
+        parse_data(movie)
+    except SiteBlocked:
+        raise
+        logger.error('JavDB: 可能触发了反爬虫机制，请稍后再试')
+    # 将此功能放在各个抓取器以保持数据的一致，避免影响转换（写入nfo时的信息来自多个抓取器的汇总，数据来源一致性不好）
+    if cfg.Crawler.title__remove_actor:
+        new_title = remove_trail_actor_in_title(movie.title, movie.actress)
+        if new_title != movie.title:
+            movie.ori_title = movie.title
+            movie.title = new_title
 
 if __name__ == "__main__":
     import pretty_errors
@@ -116,7 +130,7 @@ if __name__ == "__main__":
 
     movie = MovieInfo('FC2-12345')
     try:
-        parse_data(movie)
+        parse_clean_data(movie)
         print(movie)
     except CrawlerError as e:
         logger.error(e, exc_info=1)

--- a/web/fc2fan.py
+++ b/web/fc2fan.py
@@ -5,6 +5,7 @@ import re
 import sys
 import logging
 import lxml.html
+from core.func import remove_trail_actor_in_title
 
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -52,6 +53,20 @@ def parse_data(movie: MovieInfo):
         movie.preview_pics = preview_pics
         movie.cover = preview_pics[0]
 
+def parse_clean_data(movie: MovieInfo):
+    """解析指定番号的影片数据并进行清洗"""
+    try:
+        parse_data(movie)
+    except SiteBlocked:
+        raise
+        logger.error('JavDB: 可能触发了反爬虫机制，请稍后再试')
+    # 将此功能放在各个抓取器以保持数据的一致，避免影响转换（写入nfo时的信息来自多个抓取器的汇总，数据来源一致性不好）
+    if cfg.Crawler.title__remove_actor:
+        new_title = remove_trail_actor_in_title(movie.title, movie.actress)
+        if new_title != movie.title:
+            movie.ori_title = movie.title
+            movie.title = new_title
+
 
 if __name__ == "__main__":
     import pretty_errors
@@ -60,7 +75,7 @@ if __name__ == "__main__":
 
     movie = MovieInfo('FC2-1000967')
     try:
-        parse_data(movie)
+        parse_clean_data(movie)
         print(movie)
     except CrawlerError as e:
         logger.error(e, exc_info=1)

--- a/web/jav321.py
+++ b/web/jav321.py
@@ -3,6 +3,8 @@ import os
 import re
 import sys
 import logging
+from core.config import cfg
+from core.func import remove_trail_actor_in_title
 
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -81,6 +83,20 @@ def parse_data(movie: MovieInfo):
     movie.cover = preview_pics[0]
     movie.preview_pics = preview_pics[1:]
 
+def parse_clean_data(movie: MovieInfo):
+    """解析指定番号的影片数据并进行清洗"""
+    try:
+        parse_data(movie)
+    except SiteBlocked:
+        raise
+        logger.error('JavDB: 可能触发了反爬虫机制，请稍后再试')
+    # 将此功能放在各个抓取器以保持数据的一致，避免影响转换（写入nfo时的信息来自多个抓取器的汇总，数据来源一致性不好）
+    if cfg.Crawler.title__remove_actor:
+        new_title = remove_trail_actor_in_title(movie.title, movie.actress)
+        if new_title != movie.title:
+            movie.ori_title = movie.title
+            movie.title = new_title
+
 
 if __name__ == "__main__":
     import pretty_errors
@@ -89,7 +105,7 @@ if __name__ == "__main__":
 
     movie = MovieInfo('DCV-137')
     try:
-        parse_data(movie)
+        parse_clean_data(movie)
         print(movie)
     except CrawlerError as e:
         logger.error(e, exc_info=1)

--- a/web/javmenu.py
+++ b/web/javmenu.py
@@ -2,6 +2,8 @@
 import os
 import sys
 import logging
+from core.config import cfg
+from core.func import remove_trail_actor_in_title
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from web.base import Request, resp2html
@@ -69,6 +71,20 @@ def parse_data(movie: MovieInfo):
     movie.genre_id = genre_id
     movie.actress = actress
 
+def parse_clean_data(movie: MovieInfo):
+    """解析指定番号的影片数据并进行清洗"""
+    try:
+        parse_data(movie)
+    except SiteBlocked:
+        raise
+        logger.error('JavDB: 可能触发了反爬虫机制，请稍后再试')
+    # 将此功能放在各个抓取器以保持数据的一致，避免影响转换（写入nfo时的信息来自多个抓取器的汇总，数据来源一致性不好）
+    if cfg.Crawler.title__remove_actor:
+        new_title = remove_trail_actor_in_title(movie.title, movie.actress)
+        if new_title != movie.title:
+            movie.ori_title = movie.title
+            movie.title = new_title
+
 
 if __name__ == "__main__":
     import pretty_errors
@@ -77,7 +93,7 @@ if __name__ == "__main__":
 
     movie = MovieInfo('082713-417')
     try:
-        parse_data(movie)
+        parse_clean_data(movie)
         print(movie)
     except CrawlerError as e:
         logger.error(e, exc_info=1)

--- a/web/mgstage.py
+++ b/web/mgstage.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import logging
+from core.func import remove_trail_actor_in_title
 
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -100,6 +101,20 @@ def parse_data(movie: MovieInfo):
     movie.preview_pics = preview_pics
     movie.uncensored = False    # 服务器在日本且面向日本国内公开发售，不会包含无码片
 
+def parse_clean_data(movie: MovieInfo):
+    """解析指定番号的影片数据并进行清洗"""
+    try:
+        parse_data(movie)
+    except SiteBlocked:
+        raise
+        logger.error('JavDB: 可能触发了反爬虫机制，请稍后再试')
+    # 将此功能放在各个抓取器以保持数据的一致，避免影响转换（写入nfo时的信息来自多个抓取器的汇总，数据来源一致性不好）
+    if cfg.Crawler.title__remove_actor:
+        new_title = remove_trail_actor_in_title(movie.title, movie.actress)
+        if new_title != movie.title:
+            movie.ori_title = movie.title
+            movie.title = new_title
+
 
 if __name__ == "__main__":
     import pretty_errors
@@ -108,7 +123,7 @@ if __name__ == "__main__":
 
     movie = MovieInfo('SIRO-4718')
     try:
-        parse_data(movie)
+        parse_clean_data(movie)
         print(movie)
     except CrawlerError as e:
         logger.error(e, exc_info=1)

--- a/web/prestige.py
+++ b/web/prestige.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import logging
+from core.func import remove_trail_actor_in_title
 
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -80,6 +81,20 @@ def parse_data(movie: MovieInfo):
     movie.preview_pics = preview_pics
     movie.uncensored = False    # prestige服务器在日本且面向日本国内公开发售，不会包含无码片
 
+def parse_clean_data(movie: MovieInfo):
+    """解析指定番号的影片数据并进行清洗"""
+    try:
+        parse_data(movie)
+    except SiteBlocked:
+        raise
+        logger.error('JavDB: 可能触发了反爬虫机制，请稍后再试')
+    # 将此功能放在各个抓取器以保持数据的一致，避免影响转换（写入nfo时的信息来自多个抓取器的汇总，数据来源一致性不好）
+    if cfg.Crawler.title__remove_actor:
+        new_title = remove_trail_actor_in_title(movie.title, movie.actress)
+        if new_title != movie.title:
+            movie.ori_title = movie.title
+            movie.title = new_title
+
 
 if __name__ == "__main__":
     import pretty_errors
@@ -88,7 +103,7 @@ if __name__ == "__main__":
 
     movie = MovieInfo('ABP-647')
     try:
-        parse_data(movie)
+        parse_clean_data(movie)
         print(movie)
     except CrawlerError as e:
         logger.error(e, exc_info=1)


### PR DESCRIPTION
1. [bugfix]修正扫描文件方法中的一个BUG，修改遍历中的数组会导致后续循环错误。例如忽略目录为[a,b,c]，目录列表为[a,b,d]，原始方法的结果无法将b文件夹忽略
2. Fix #86 [bugfix]给所有抓取器增加parse_clean_data方法，保持逻辑一致，
3. Fix #85 [bugfix]导演字段名修改为director
4. [Feature] 忽略目录默认增加群晖系统的回收站目录：#recycle
5. Fix #53 [Feature] 增加enable_file_move配置项，如果设置为no，则不会自动整理文件，默认为no。
6. Todo: 提供一种一键整理已采集数据的方法。