### PR TITLE
问题修复&翻译引擎增加&字幕简单移动

### DIFF
--- a/core/config.ini
+++ b/core/config.ini
@@ -97,7 +97,7 @@ aip_api_key =
 aip_secret_key = 
 
 [Translate]
-# 翻译引擎，可选: google, bing, baidu （Google可以直接免费使用。留空表示禁用翻译功能）
+# 翻译引擎，可选: google, bing, baidu,deepl （Google可以直接免费使用。留空表示禁用翻译功能）
 # 进阶功能的文档 https://github.com/Yuukiy/JavSP/wiki/Translation-%7C-%E7%BF%BB%E8%AF%91
 engine = 
 # 是否翻译标题
@@ -108,7 +108,9 @@ translate_plot = yes
 baidu_appid = 
 baidu_key = 
 # 微软必应翻译（Azure 认知服务 → 翻译）的密钥
-bing_key = 
+bing_key =
+# Deepl免费版的密钥
+deepl_key =
 
 [NFO]
 # 同时将genre写入到tag？

--- a/core/config.py
+++ b/core/config.py
@@ -289,6 +289,8 @@ def validate_translation(cfg: Config):
     trans.baidu_appid = os.getenv('JAVSP_BAIDU_APPID', trans.baidu_appid)
     trans.baidu_key = os.getenv('JAVSP_BAIDU_KEY', trans.baidu_key)
     trans.bing_key = os.getenv('JAVSP_BING_KEY', trans.bing_key)
+    trans.deepl_key = os.getenv('JAVSP_DEEPL_KEY', trans.deepl_key)
+
     # 先获取访问凭据再判断翻译引擎，这样的话即使配置文件中未启用翻译也可以调试翻译功能
     if trans.engine == '':
         return
@@ -307,6 +309,11 @@ def validate_translation(cfg: Config):
             logger.error('启用必应翻译时，key不能留空')
     elif engine_name == 'google':
         cfg.Translate.engine = engine_name
+    elif engine_name == 'deepl':
+        if trans.deepl_key:
+            cfg.Translate.engine = engine_name
+        else:
+            logger.error('启用Deepl翻译时，key不能留空')
     else:
         logger.error('无效的翻译引擎: ' + engine_name)
 

--- a/core/datatype.py
+++ b/core/datatype.py
@@ -1,6 +1,7 @@
 """定义数据类型和一些通用性的对数据类型的操作"""
 import os
 import csv
+import re
 import sys
 import json
 import logging
@@ -138,6 +139,26 @@ class Movie:
             logger.info(f"重命名文件: '{src_rel}' -> '...{os.sep}{dst_name}'")
             # 目前StreamHandler并未设置filter，为了避免显示中出现重复的日志，这里暂时只能用debug级别
             filemove_logger.debug(f'移动（重命名）文件: \n  原路径: "{src}"\n  新路径: "{abs_dst}"')
+        def find_move_subs(src_dir:str):
+            """移动（重命名）字幕并记录信息到日志"""
+            sub = None
+            for file in os.listdir(src_dir):
+                if re.match(r".*\.(ass|srt)$",file):
+                    if self.basename.lower() in file.lower():
+                        sub = file
+                        break
+            if sub:
+                sub_src = os.path.join(src_dir,sub)
+                ext = os.path.splitext(sub_src)[1]
+                newpath = os.path.join(self.save_dir, self.basename + ext)
+                abs_dst = os.path.abspath(newpath)
+                os.rename(sub_src, abs_dst)
+                src_rel = os.path.relpath(sub_src)
+                dst_name = os.path.basename(newpath)
+                logger.info(f"重命名字幕文件: '{src_rel}' -> '...{os.sep}{dst_name}'")
+                # 目前StreamHandler并未设置filter，为了避免显示中出现重复的日志，这里暂时只能用debug级别
+                filemove_logger.debug(f'移动（重命名）字幕文件: \n  原路径: "{sub_src}"\n  新路径: "{abs_dst}"')
+
 
         new_paths = []
         if len(self.files) == 1:
@@ -145,6 +166,7 @@ class Movie:
             ext = os.path.splitext(fullpath)[1]
             newpath = os.path.join(self.save_dir, self.basename + ext)
             move_file(fullpath, newpath)
+            find_move_subs(os.path.dirname(fullpath))
             new_paths.append(newpath)
         else:
             for i, fullpath in enumerate(self.files, start=1):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ tqdm==4.59.0
 urllib3==1.26.5
 pywin32==303
 pywin32-ctypes==0.2.0
+urllib3==1.25.11

--- a/web/translate.py
+++ b/web/translate.py
@@ -155,7 +155,7 @@ def google_trans(texts, to='zh_CN'):
     """使用Google翻译文本（默认翻译为简体中文）"""
     # API: https://www.jianshu.com/p/ce35d89c25c3
     # client参数的选择: https://github.com/lmk123/crx-selection-translate/issues/223#issue-184432017
-    url = f"http://translate.google.cn/translate_a/single?client=at&dt=t&dj=1&ie=UTF-8&sl=auto&tl={to}&q=" + texts
+    url = f"http://translate.google.com/translate_a/single?client=at&dt=t&dj=1&ie=UTF-8&sl=auto&tl={to}&q=" + texts
     r = requests.get(url)
     if r.status_code == 200:
         result = r.json()

--- a/web/translate.py
+++ b/web/translate.py
@@ -142,7 +142,7 @@ def bing_translate(texts, to='zh-Hans'):
 def deepl_translate(texts, to='zh'):
     """使用Deepl翻译文本（默认翻译为简体中文）"""
     api_url = "https://api-free.deepl.com/v2/translate"
-    params = {'text': texts, 'target_lang': to}
+    params = {'text': texts, 'target_lang': to, 'source_lang': 'ja'}
     headers = {
         'Authorization': f"DeepL-Auth-Key {cfg.Translate.deepl_key}"
     }

--- a/web/translate.py
+++ b/web/translate.py
@@ -156,13 +156,10 @@ def google_trans(texts, to='zh_CN'):
     # API: https://www.jianshu.com/p/ce35d89c25c3
     # client参数的选择: https://github.com/lmk123/crx-selection-translate/issues/223#issue-184432017
     url = f"http://translate.google.com/translate_a/single?client=at&dt=t&dj=1&ie=UTF-8&sl=auto&tl={to}&q=" + texts
+    time.sleep(random.randint(5,10))
     r = requests.get(url)
     if r.status_code == 200:
         result = r.json()
-    elif r.status_code == 429:
-        time.sleep(1)
-        logger.error('Google翻译请求过多，等待1s重试')
-        return google_trans(texts,to)
     else:
         result = {'error_code': r.status_code, 'error_msg': r.reason}
     return result

--- a/web/translate.py
+++ b/web/translate.py
@@ -159,6 +159,10 @@ def google_trans(texts, to='zh_CN'):
     r = requests.get(url)
     if r.status_code == 200:
         result = r.json()
+    elif r.status_code == 429:
+        time.sleep(1)
+        logger.error('Google翻译请求过多，等待1s重试')
+        return google_trans(texts,to)
     else:
         result = {'error_code': r.status_code, 'error_msg': r.reason}
     return result

--- a/web/translate.py
+++ b/web/translate.py
@@ -147,7 +147,10 @@ def deepl_translate(texts, to='zh'):
         'Authorization': f"DeepL-Auth-Key {cfg.Translate.deepl_key}"
     }
     r = requests.post(api_url, params=params, headers=headers)
-    result = r.json()
+    if r.status_code == 200:
+        result = r.json()
+    else:
+        result = {'error_code': r.status_code, 'error_msg': r.text}
     return result
 
 

--- a/web/translate.py
+++ b/web/translate.py
@@ -142,7 +142,7 @@ def bing_translate(texts, to='zh-Hans'):
 def deepl_translate(texts, to='zh'):
     """使用Deepl翻译文本（默认翻译为简体中文）"""
     api_url = "https://api-free.deepl.com/v2/translate"
-    params = {'text': texts, 'target_lang': to, 'source_lang': "ja"}
+    params = {'text': texts, 'target_lang': to}
     headers = {
         'Authorization': f"DeepL-Auth-Key {cfg.Translate.deepl_key}"
     }

--- a/web/translate.py
+++ b/web/translate.py
@@ -144,7 +144,7 @@ def deepl_translate(texts, to='zh'):
     api_url = "https://api-free.deepl.com/v2/translate"
     params = {'text': texts, 'target_lang': to, 'source_lang': "ja"}
     headers = {
-        'Authorization': f"DeepL-Auth-Key {cfg.Translate.deepl_key}:fx"
+        'Authorization': f"DeepL-Auth-Key {cfg.Translate.deepl_key}"
     }
     r = requests.post(api_url, params=params, headers=headers)
     result = r.json()

--- a/web/translate.py
+++ b/web/translate.py
@@ -105,6 +105,17 @@ def translate(texts, engine='google', actress=[]):
                 err_msg = "{}: {}: {}".format(engine, result['error_code'], result['error_msg'])
         except Exception as e:
             err_msg = "{}: {}: Exception: {}".format(engine, -2, repr(e))
+    elif engine == 'deepl':
+        try:
+            result = deepl_translate(texts)
+            if 'translations' in result:
+                paragraphs = [i['text'] for i in result['translations']]
+                rtn = {'trans': '\n'.join(paragraphs)}
+            else:
+                err_msg = "{}: {}: {}".format(engine, result['error_code'], result['error_msg'])
+        except Exception as e:
+            err_msg = "{}: {}: Exception: {}".format(engine, -2, repr(e))
+
     # else:
         # 配置文件中已经检查过翻译引擎，这里不再检查，因此如果使用不在列表中的翻译引擎，会出错
     # 如果err_msg非空，说明发生了错误，返回错误消息
@@ -125,6 +136,17 @@ def bing_translate(texts, to='zh-Hans'):
     }
     body = [{'text': texts}]
     r = requests.post(api_url, params=params, headers=headers, json=body)
+    result = r.json()
+    return result
+
+def deepl_translate(texts, to='zh'):
+    """使用Deepl翻译文本（默认翻译为简体中文）"""
+    api_url = "https://api-free.deepl.com/v2/translate"
+    params = {'text': texts, 'target_lang': to, 'source_lang': "ja"}
+    headers = {
+        'Authorization': f"DeepL-Auth-Key {cfg.Translate.deepl_key}:fx"
+    }
+    r = requests.post(api_url, params=params, headers=headers)
     result = r.json()
     return result
 


### PR DESCRIPTION
- 修复了 Google 翻译国内站下线之后导致翻译不可用问题 （但是会触发429，我在code随机加入了延迟但不一定能解决此问题，不推荐用，看起来会ban ip，不确定多久会解除）
- 新加入了DeepL翻译接口，可以注册获取免费的API，完全足够使用
- 回退了urllib3的版本，具体问题见 https://stackoverflow.com/questions/66642705/why-requests-raise-this-exception-check-hostname-requires-server-hostname 在我本机的效果是如果设置代理会导致requests报错，回退urllib3版本之后一切正常，可能也可修复 #97 
- 加入了单视频文件的的字幕自动匹配与移动，多文件的暂时没想到可能的命名规则（没遇到过）