### PR TITLE
人体识别调用判断条件修复

### DIFF
--- a/JavSP.py
+++ b/JavSP.py
@@ -359,7 +359,7 @@ def reviewMovieID(all_movies, root):
 
 def crop_poster_wrapper(fanart_file, poster_file, method='normal'):
     """包装各种海报裁剪方法，提供统一的调用"""
-    if cfg.Picture.ai_engine == 'baidu':
+    if method == 'baidu':
         try:
             aip_crop_poster(fanart_file, poster_file)
         except Exception as e:


### PR DESCRIPTION
这个地方写成了只要设置了人体裁剪API就会调用，根据番号调用的规则被绕过了。