### PR TITLE
添加用户选择多文件尾部命名方式

### DIFF
--- a/JavSP.py
+++ b/JavSP.py
@@ -277,20 +277,29 @@ def generate_names(movie: Movie):
         ori_title_break = split_by_punc(d['rawtitle'])
     copyd = d.copy()
     copyd['num'] = copyd['num'] + movie.attr_str
+    longest_ext = max((os.path.splitext(i)[1] for i in movie.files), key=len)
     for end in range(len(ori_title_break), 0, -1):
         copyd['rawtitle'] = replace_illegal_chars(''.join(ori_title_break[:end]).strip())
         for sub_end in range(len(title_break), 0, -1):
             copyd['title'] = replace_illegal_chars(''.join(title_break[:sub_end]).strip())
             save_dir = os.path.normpath(cfg.NamingRule.save_dir.substitute(copyd)).strip()
             basename = os.path.normpath(cfg.NamingRule.filename.substitute(copyd).strip())
-            fanart_file = os.path.join(save_dir, f'{basename}{cdx}-fanart.jpg')
-            remaining = get_remaining_path_len(os.path.abspath(fanart_file))
+            if 'universal' in cfg.NamingRule.media_servers:
+                long_path = os.path.join(save_dir, basename+longest_ext)
+            else:
+                long_path = os.path.join(save_dir, f'{basename}{cdx}-fanart.jpg')
+            remaining = get_remaining_path_len(os.path.abspath(long_path))
             if remaining > 0:
                 movie.save_dir = save_dir
                 movie.basename = basename
-                movie.nfo_file = os.path.join(save_dir, f'{basename}{cdx}.nfo')
-                movie.fanart_file = fanart_file
-                movie.poster_file = os.path.join(save_dir, f'{basename}{cdx}-poster.jpg')
+                if 'universal' in cfg.NamingRule.media_servers:
+                    movie.nfo_file = os.path.join(save_dir, 'movie.nfo')
+                    movie.fanart_file = os.path.join(save_dir, 'fanart.jpg')
+                    movie.poster_file = os.path.join(save_dir, 'poster.jpg')
+                else:
+                    movie.nfo_file = os.path.join(save_dir, f'{basename}{cdx}.nfo')
+                    movie.fanart_file = os.path.join(save_dir, f'{basename}{cdx}-fanart.jpg')
+                    movie.poster_file = os.path.join(save_dir, f'{basename}{cdx}-poster.jpg')
                 if d['title'] != copyd['title']:
                     logger.info(f"自动截短标题为:\n{copyd['title']}")
                 if d['rawtitle'] != copyd['rawtitle']:
@@ -308,9 +317,14 @@ def generate_names(movie: Movie):
         save_dir = os.path.normpath(cfg.NamingRule.save_dir.substitute(copyd)).strip()
         movie.save_dir = save_dir
         movie.basename = os.path.normpath(cfg.NamingRule.filename.substitute(copyd)).strip()
-        movie.nfo_file = os.path.join(save_dir, f'{basename}{cdx}.nfo')
-        movie.fanart_file = os.path.join(save_dir, f'{basename}{cdx}-fanart.jpg')
-        movie.poster_file = os.path.join(save_dir, f'{basename}{cdx}-poster.jpg')
+        if 'universal' in cfg.NamingRule.media_servers:
+            movie.nfo_file = os.path.join(save_dir, 'movie.nfo')
+            movie.fanart_file = os.path.join(save_dir, 'fanart.jpg')
+            movie.poster_file = os.path.join(save_dir, 'poster.jpg')
+        else:
+            movie.nfo_file = os.path.join(save_dir, f'{basename}{cdx}.nfo')
+            movie.fanart_file = os.path.join(save_dir, f'{basename}{cdx}-fanart.jpg')
+            movie.poster_file = os.path.join(save_dir, f'{basename}{cdx}-poster.jpg')
         if d['title'] != copyd['title']:
             logger.info(f"自动截短标题为:\n{copyd['title']}")
         if d['rawtitle'] != copyd['rawtitle']:
@@ -452,7 +466,7 @@ def RunNormalMode(all_movies):
 
             if 'video_station' in cfg.NamingRule.media_servers:
                 postStep_videostation(movie)
-            if len(movie.files) > 1:
+            if len(movie.files) > 1 and 'universal' not in cfg.NamingRule.media_servers:
                 postStep_MultiMoviePoster(movie)
 
             inner_bar.set_description('写入NFO')

--- a/core/config.ini
+++ b/core/config.ini
@@ -64,8 +64,8 @@ javlib = https://www.a66j.com
 # save_dir, nfo_title和filename中可以使用变量来引用影片的数据，支持的变量列表见下面的地址:
 # https://github.com/Yuukiy/JavSP/wiki/NamingRule-%7C-%E5%91%BD%E5%90%8D%E8%A7%84%E5%88%99
 [NamingRule]
-# 设置媒体服务器类型
-media_servers = jellyfin
+# 设置媒体服务器类型 (universal/jellyfin/video_station, 默认universal: 按兼容性最高的方式命名封面和nfo)
+media_servers = universal
 # 整理后的影片和封面等文件的保存位置
 output_folder = #整理完成
 # 存放影片、封面等文件的文件夹路径

--- a/core/config.py
+++ b/core/config.py
@@ -291,7 +291,7 @@ def norm_ignore_pattern(cfg: Config):
 
 def validate_media_servers(cfg: Config):
     """获取媒体服务器配置并验证有效性"""
-    supported = set(('plex', 'emby', 'jellyfin', 'kodi', 'video_station'))
+    supported = set(('universal', 'plex', 'emby', 'jellyfin', 'kodi', 'video_station'))
     servers = cfg.NamingRule.media_servers.lower()
     items = set(re.split(r'[^\w_]+', servers, flags=re.I))
     cfg.NamingRule.media_servers = items & supported


### PR DESCRIPTION
1. 添加用户选择多文件尾部命名方式；
2. 电影信息相关文件调整为‘文件名.NFO’、‘文件名-poster.NFO’等；
3. 将番号头（例如IPX、FC2）作为单独参数添加入director，方便直接查看该系列；
4. 测试Kodi、PLEX（需要配合[XBMCnfoMoviesImporter](https://github.com/gboudreau/XBMCnfoMoviesImporter.bundle)使用）和jellyfin三款软件。
测试环境：  群晖

PS：将有多文件的影片命名为name-part1、name-part2，Kodi和PLEX会将多文件识别为一个文件进行播放，多文件的进度条合并
