### PR TITLE
处理好未找到头像的情况

### DIFF
--- a/JavSP.py
+++ b/JavSP.py
@@ -247,11 +247,12 @@ def info_summary(movie: Movie, all_info: Dict[str, MovieInfo]):
             final_info.ori_title = final_info.title
 
     # 女优别名固定
-    if cfg.NFO.fix_actress_name:
+    if cfg.NFO.fix_actress_name and final_info.actress is not None:
         final_info.actress = [resolve_alias(i) for i in final_info.actress]
-        final_info.actress_pics = {
-            resolve_alias(key): value for key, value in final_info.actress_pics.items()
-        }
+        if final_info.actress_pics != None:
+            final_info.actress_pics = {
+                resolve_alias(key): value for key, value in final_info.actress_pics.items()
+            }
 
     # 检查是否所有必需的字段都已经获得了值
     for attr in cfg.Crawler.required_keys:
@@ -455,7 +456,9 @@ def RunNormalMode(all_movies):
             check_step(all_info, msg)
 
             inner_bar.set_description('汇总数据')
+            logger.info(f"bro2{movie}{all_info}")
             has_required_keys = info_summary(movie, all_info)
+            logger.info("bro3")
             check_step(has_required_keys)
 
             if cfg.Translate.engine:

--- a/core/nfo.py
+++ b/core/nfo.py
@@ -91,10 +91,12 @@ def write_nfo(info: MovieInfo, nfo_file):
     # 写入演员名。Kodi支持用thumb显示演员头像，如果能获取到演员头像也一并写入
     if info.actress:
         for i in info.actress:
-            if (info.actress_pics) and (i in info.actress_pics):
+            print("bro")
+            if (info.actress_pics is not None) and (i in info.actress_pics):
                 nfo.append(E.actor(E.name(i), E.thumb(info.actress_pics[i])))
             else:
                 nfo.append(E.actor(E.name(i)))
+            print("yeah")
 
     with open(nfo_file, 'wt', encoding='utf-8') as f:
         f.write(tostring(nfo, encoding='unicode', pretty_print=True,

--- a/core/nfo.py
+++ b/core/nfo.py
@@ -91,12 +91,10 @@ def write_nfo(info: MovieInfo, nfo_file):
     # 写入演员名。Kodi支持用thumb显示演员头像，如果能获取到演员头像也一并写入
     if info.actress:
         for i in info.actress:
-            print("bro")
             if (info.actress_pics is not None) and (i in info.actress_pics):
                 nfo.append(E.actor(E.name(i), E.thumb(info.actress_pics[i])))
             else:
                 nfo.append(E.actor(E.name(i)))
-            print("yeah")
 
     with open(nfo_file, 'wt', encoding='utf-8') as f:
         f.write(tostring(nfo, encoding='unicode', pretty_print=True,


### PR DESCRIPTION
如果info_summary没有读取到头像，程序会报错，因为actress_pics映射过程中假定了列表存在。这个patch先检查了一下对应的信息是否是None再进行映射。