### PR TITLE
增加选项控制只刮削不整理；删除整理后的空文件夹

### DIFF
--- a/core/config.ini
+++ b/core/config.ini
@@ -12,7 +12,7 @@ ignore_regex = \w+2048\.com;Carib(beancom)?;[^a-z\d](f?hd|lt)[^a-z\d]
 # 整理哪个文件夹下的影片？（此项留空时将在运行时询问）
 scan_dir = 
 ## 哪些后缀的文件应当视为影片？
-media_ext = 3gp;avi;f4v;flv;iso;m2ts;m4v;mkv;mov;mp4;mpeg;rm;rmvb;ts;vob;webm;wmv;strm
+media_ext = 3gp;avi;f4v;flv;iso;m2ts;m4v;mkv;mov;mp4;mpeg;rm;rmvb;ts;vob;webm;wmv;strm;mpg
 # 扫描影片文件时忽略指定的文件夹（以.开头的文件夹不需要设置也会被忽略）
 ignore_folder = #recycle;#整理完成;不要扫描
 # 匹配番号时忽略小于指定大小的文件（以MiB为单位，0表示禁用此功能）

--- a/core/config.ini
+++ b/core/config.ini
@@ -17,6 +17,8 @@ media_ext = 3gp;avi;f4v;flv;iso;m2ts;m4v;mkv;mov;mp4;mpeg;rm;rmvb;ts;vob;webm;wm
 ignore_folder = #recycle;#整理完成;不要扫描
 # 匹配番号时忽略小于指定大小的文件（以MiB为单位，0表示禁用此功能）
 ignore_video_file_less_than = 232
+# 整理时是否移动文件: yes-移动所有文件到新文件夹; no-数据保存到同级文件夹，不移动文件
+enable_file_move = yes
 
 [Network]
 # 是否启用代理

--- a/core/config.py
+++ b/core/config.py
@@ -266,7 +266,8 @@ def norm_boolean(cfg: Config):
             ('Picture', 'use_ai_crop'),
             ('NFO', 'add_genre_to_tag'),
             ('Other', 'check_update'),
-            ('Other', 'auto_update')
+            ('Other', 'auto_update'),
+            ('File', 'enable_file_move'),
         ]:
         cfg._sections[sec][key] = cfg.getboolean(sec, key)
     # 特殊转换

--- a/core/datatype.py
+++ b/core/datatype.py
@@ -158,6 +158,7 @@ class Movie:
             filemove_logger.debug(f'移动（重命名）文件: \n  原路径: "{src}"\n  新路径: "{abs_dst}"')
 
         new_paths = []
+        dir = os.path.dirname(self.files[0])
         if len(self.files) == 1:
             fullpath = self.files[0]
             ext = os.path.splitext(fullpath)[1]
@@ -171,6 +172,9 @@ class Movie:
                 move_file(fullpath, newpath)
                 new_paths.append(newpath)
         self.new_paths = new_paths
+        if len(os.listdir(dir)) == 0:
+            #如果移动文件后目录为空则删除该目录
+            os.rmdir(dir)
 
 
 class GenreMap(dict):


### PR DESCRIPTION
Fixes #258
Fixes #251 
Fixes #245
Fixes #104 

增加配置项File.enable_file_move，默认yes. yes-刮削且整理，no-只刮削不整理
只刮削不整理修改了save_dir和basename的生成逻辑，并且最后不调用Movie.rename_files；
目前存在一个bug是如果给每一个分片文件创建poster，分片后缀会附加在CD1的完整文件名后面；不过经测试jellyfin不需要为每一个分片创建poster，我把postStep_MultiMoviePoster函数注释了。