### PR TITLE
增加只刮削，只识别等命令行参数配合GUI

### DIFF
--- a/core/config.ini
+++ b/core/config.ini
@@ -60,7 +60,7 @@ ignore_javdb_cover = auto
 # 各个站点的免代理地址。地址失效时软件会自动尝试获取新地址，你也可以手动设置
 [ProxyFree]
 avsox = https://avsox.click
-javdb = https://javdb523.com
+javdb = https://javdb365.com
 javbus = https://www.busdmm.shop
 javlib = https://www.i71t.com
 

--- a/core/config.py
+++ b/core/config.py
@@ -397,6 +397,9 @@ def parse_args():
                         help="由用户介入番号识别过程，可选值为：\n'all': 检查所有番号\n'failed': 仅检查无法识别的番号（默认）")
     parser.add_argument('-e', '--auto-exit', action='store_true', help='运行结束后自动退出')
     parser.add_argument('-s', '--shutdown', action='store_true', help='整理完成后关机')
+    parser.add_argument('--data-cache-file', help='存储数据的缓存文件，临时文件，供进程间通信使用')
+    parser.add_argument('--only-scan', action='store_true', help='仅识别，不刮削')
+    parser.add_argument('--only-fetch', action='store_true', help='仅刮削data-cache-file缓存文件中的数据')
     # 忽略无法识别的参数，避免传入供pytest使用的参数时报错
     args, unknown = parser.parse_known_args()
 
@@ -431,6 +434,8 @@ def parse_args():
         msg = f"{parser.prog}: error: argument -m/--manual: invalid choice: '{args.manual}' (choose from 'all', 'failed' or leave it empty)"
         # 使用SystemExit异常以避免显示traceback信息
         raise SystemExit(msg)
+    if (args.only_scan == True or args.only_fetch == True) and args.data_cache_file == None:
+        raise SystemExit("当仅刮削或者仅识别时，必须传入缓存文件路径")
     args.config = cfg_file
     return args
 
@@ -453,6 +458,9 @@ def overwrite_cfg(cfg, args):
         cfg.File.scan_dir = args.input
     if args.output:
         cfg.NamingRule.output_folder = args.output
+    if args.only_fetch == True:
+        # 如果仅刮削，则不会整理文件
+        cfg.File.enable_file_move = 'no'
 
 
 cfg = Config()

--- a/core/datatype.py
+++ b/core/datatype.py
@@ -116,6 +116,7 @@ class Movie:
         self.nfo_file = None            # nfo文件的路径
         self.fanart_file = None         # fanart文件的路径
         self.poster_file = None         # poster文件的路径
+        self.guid = None                # GUI使用的唯一标识，通过dvdid和files做md5生成
 
     @cached_property
     def hard_sub(self) -> bool:

--- a/web/proxyfree.py
+++ b/web/proxyfree.py
@@ -62,7 +62,7 @@ def _get_javlib_urls() -> list:
 
 
 def _get_javdb_urls() -> list:
-    html = get_html('https://jav523.app')
+    html = get_html('https://jav524.app')
     js_links = html.xpath("//script[@src]/@src")
     for link in js_links:
         if '/js/index' in link:


### PR DESCRIPTION
增加命令行参数，并作对应逻辑修改
- --only-fetch 只刮削，待刮削数据从--data-cache-file读取，刮削完成后数据回写到--data-cache-file
- --only-scan 只识别，识别结果写入--data-cache-file
只刮削模式不会整理文件，不会自动升级（升级也没问题，就是有点慢，所以默认关闭了）

基本的操作逻辑就是在GUI程序中使用子进程启动JavSP，然后通过--data-cache-file来做数据交换

目前GUI已经完成功能预览版: [JavSPN](https://github.com/qicfan/JavSPN)，现在只有windows版本，后续我会尝试在linux和mac下打包JavSP，如果通过则会提供linux和mac版本