### PR TITLE
新增getchu官网刮削，支持同人和里番

### DIFF
--- a/core/avid.py
+++ b/core/avid.py
@@ -80,6 +80,9 @@ def get_id(filepath: str) -> str:
     match = re.search(r'(T28[-_]\d{3})', filename)
     if match:
         return match.group(1)
+    match = re.search(r'(T38[-_]\d{3})', filename)
+    if match:
+        return match.group(1)
     # 尝试匹配东热n, k系列
     match = re.search(r'(n\d{4}|k\d{4})', filename, re.I)
     if match:

--- a/core/config.py
+++ b/core/config.py
@@ -246,6 +246,8 @@ def norm_tuples(cfg: Config):
     cfg.File.media_ext = tuple(exts)
     # ignore_folder: 转换为元组
     items = cfg.File.ignore_folder.split(';')
+    # 将整理后的文件夹加入不扫描列表
+    items.append(cfg.NamingRule.output_folder)
     cfg.File.ignore_folder = tuple(items)
     # required_keys: 转换为元组
     items = cfg.Crawler.required_keys.split(',')

--- a/web/arzon.py
+++ b/web/arzon.py
@@ -1,0 +1,98 @@
+"""从arzon抓取数据"""
+import os
+import sys
+import logging
+import re
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from web.base import resp2html, request_get
+from web.exceptions import *
+from core.config import cfg
+from core.datatype import MovieInfo
+import requests
+from lxml import html
+
+logger = logging.getLogger(__name__)
+base_url = "https://www.arzon.jp"
+
+def get_cookie():
+    # https://www.arzon.jp/index.php?action=adult_customer_agecheck&agecheck=1&redirect=https%3A%2F%2Fwww.arzon.jp%2F
+    skip_verify_url = "http://www.arzon.jp/index.php?action=adult_customer_agecheck&agecheck=1"
+    session = requests.Session()
+    session.get(skip_verify_url, timeout=(12, 7))
+    return session.cookies.get_dict()
+
+def parse_data(movie: MovieInfo):
+    """解析指定番号的影片数据"""
+    full_id = movie.dvdid
+    cookies = get_cookie()
+    url = f'{base_url}/itemlist.html?t=&m=all&s=&q={full_id}'
+    r = request_get(url, cookies, delay_raise=True)
+    if r.status_code == 404:
+      raise MovieNotFoundError(__name__, movie.dvdid)
+    # https://stackoverflow.com/questions/15830421/xml-unicode-strings-with-encoding-declaration-are-not-supported
+    data = html.fromstring(r.content)
+
+    urls = data.xpath("//div[@class='pictlist']//h2/a/@href")
+    print(url)
+    if len(url) == 0:
+        raise MovieNotFoundError(__name__, movie.dvdid)
+
+    item_url = base_url + urls[0]
+    e = request_get(item_url, cookies, delay_raise=True)
+    item =  html.fromstring(e.content)
+
+    title = item.xpath("//div[@class='detail_title_new2']//h1/text()")[0]
+    cover = item.xpath("//td[@align='center']//a/img/@src")[0]
+    preview_pics_arr = item.xpath("//div[@class='detail_img']//img/@src")
+    # 使用列表推导式添加 "http:" 并去除 "m_"
+    preview_pics = [("https:" + url).replace("m_", "") for url in preview_pics_arr]
+
+    container = item.xpath("//div[@class='item_register']/table//tr")
+    for row in container:
+      key = row.xpath("./td[1]/text()")[0]
+      contents = row.xpath("./td[2]//text()")
+      content = [item.strip() for item in contents if item.strip() != '']
+      index = 0
+      value = content[index] if content and index < len(content) else None
+      if key == "AV女優：":
+        movie.actress = content
+      if key == "AVメーカー：":
+        movie.producer = value
+      if key == "AVレーベル：":
+        video_type = value
+      if key == "シリーズ：":
+        movie.serial = value
+      if key == "監督：":
+        movie.director = value
+      if key == "発売日：" and value:
+        # publish_date = content[0].split(" ")[0].replace("/", "-")
+        movie.publish_date = re.search(r"\d{4}/\d{2}/\d{2}", value).group(0).replace("/", "-")
+      if key == "収録時間：" and value:
+        movie.duration = re.search(r'([\d.]+)分', value).group(1)
+      if key == "品番：":
+        dvd_id = value
+      elif key == "タグ：":
+        genre  = value
+
+    genres = [video_type]
+    if(genre != None):
+      genres.append(genre)
+
+    movie.genre = genres
+    movie.url = item_url
+    movie.title = title
+    movie.cover = f'https:{cover}'
+    movie.preview_pics = preview_pics
+
+if __name__ == "__main__":
+    import pretty_errors
+    pretty_errors.configure(display_link=True)
+    logger.root.handlers[1].level = logging.DEBUG
+
+    movie = MovieInfo('csct-012')
+    try:
+        parse_data(movie)
+        print(movie)
+    except CrawlerError as e:
+        logger.error(e, exc_info=1)

--- a/web/getchu.py
+++ b/web/getchu.py
@@ -1,0 +1,82 @@
+"""从getchu官网抓取数据"""
+import os
+import re
+import sys
+import logging
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from web.base import resp2html, request_get
+from web.exceptions import *
+from core.datatype import MovieInfo
+
+logger = logging.getLogger(__name__)
+# dl.getchu用utf-8会乱码
+base_encode = 'euc-jp'
+
+def parse_data(movie: MovieInfo):
+    """解析指定番号的影片数据"""
+    # 去除番号中的'GETCHU'字样
+    id_uc = movie.dvdid.upper()
+    if not id_uc.startswith('GETCHU-'):
+        raise ValueError('Invalid GETCHU number: ' + movie.dvdid)
+    getchu_id = id_uc.replace('GETCHU-', '')
+    # 抓取网页
+    url = f'https://www.getchu.com/soft.phtml?id={getchu_id}&gc=gc'
+    r = request_get(url, delay_raise=True)
+    if r.status_code == 404:
+        raise MovieNotFoundError(__name__, movie.dvdid)
+    html = resp2html(r, base_encode)
+
+    title = html.xpath('//*[@id="soft-title"]/text()')[0].strip()
+
+    table = html.xpath('//table[@style="padding:1px;"]//tr')
+    producer_keys = ["サークル：","ブランド："]
+    for row in table:
+        key = row.xpath('.//td[@valign="top"]/text()')
+        if len(key) > 0:
+            key = key[0]
+        if key in producer_keys:
+            if key == producer_keys[0]:
+                producer = row.xpath('.//td[@align="top"]/text()')
+            elif key == producer_keys[1]:
+                producer = row.xpath('.//td[@align="top"]/a/text()')[0]
+        elif key == "発売日：":
+            date = row.xpath('.//td[@align="top"]/a/text()')[0]
+            date_time = time.strptime(date, "%Y/%m/%d")
+            publish_date = time.strftime("%Y-%m-%d", date_time)
+        elif key == "サブジャンル：":
+            genre = row.xpath('.//td[@align="top"]/a/text()')
+
+    remove_genre_items = ['[一覧]']
+    for item in remove_genre_items:
+        if item in genre:
+            genre.remove(item)
+
+    brand = html.xpath('//*[@align="top"]/text()')[0].strip()
+    description = html.xpath('//*[@class="tablebody"]/text()')
+    image_url = html.xpath('//*[@class="highslide"]/img/@src')
+
+    movie.title = title
+    movie.cover = image_url[0]
+    movie.preview_pics = image_url
+    movie.dvdid = id_uc
+    movie.url = url
+    movie.producer = producer
+    movie.publish_date = publish_date
+    movie.genre = genre
+    movie.plot = description
+
+
+if __name__ == "__main__":
+    import pretty_errors
+
+    pretty_errors.configure(display_link=True)
+    logger.root.handlers[1].level = logging.DEBUG
+
+    movie = MovieInfo('getchu-1280188')
+    try:
+        parse_data(movie)
+        print(movie)
+    except CrawlerError as e:
+        logger.error(e, exc_info=1)

--- a/web/msin.py
+++ b/web/msin.py
@@ -79,7 +79,7 @@ def fc2_parser(movie: MovieInfo, html):
     container = html.xpath("//div[@id='top_content']")[0]
     info = container.xpath("div/div/div[@id='movie_info_ditail']")[0]
     avid = info.xpath("div[@class='mv_fileName']/text()")[0].upper()
-    title_arr = info.xpath("//div[@class='mv_title']//text()")
+    title_arr = info.xpath("div[contains(@class, 'mv_title')]//text()")
     title = ''.join(title_arr)
     # 部分影片有预览图，但是是跳转到FC2进行预览的，且预览地址是通过js脚本解析的（带有key）
     cover_tag = container.xpath("//div[@class='movie_top']/img/@src")

--- a/web/msin.py
+++ b/web/msin.py
@@ -79,7 +79,8 @@ def fc2_parser(movie: MovieInfo, html):
     container = html.xpath("//div[@id='top_content']")[0]
     info = container.xpath("div/div/div[@id='movie_info_ditail']")[0]
     avid = info.xpath("div[@class='mv_fileName']/text()")[0].upper()
-    title = info.xpath("div[contains(@class, 'mv_title')]/text()")[0]
+    title_arr = info.xpath("//div[@class='mv_title']//text()")
+    title = ''.join(title_arr)
     # 部分影片有预览图，但是是跳转到FC2进行预览的，且预览地址是通过js脚本解析的（带有key）
     cover_tag = container.xpath("//div[@class='movie_top']/img/@src")
     if cover_tag:


### PR DESCRIPTION
[新增getchu官网刮削，支持同人和里番](https://github.com/Yuukiy/JavSP/commit/d5012d00ed4f708508f283958cbdacc88a20a266)
[将整理后的文件夹加入不扫描列表](https://github.com/Yuukiy/JavSP/commit/dec9dbfd24a860151d4d626f6b50b3baaeb6347f)

还有个自定义番号的想法，可以直接使用自定义番号列表映射一个表出来，使用特定的刮削模块处理后返回即可。
因为有些fc2和getchu作者会使用自行定义的“番号”，常见于同人cosplay作品比如cosh、pnme、CP等等，并非统一、正规的“番号”。
我打算将切削模块的parse_data方法改造一下，原来的数据不变但会return movie到新的自定义模块中。
如果作者觉得可行我会提交pr