### PR TITLE
修复censor 字段的逻辑与原逻辑不一致的问题

### DIFF
--- a/javsp/__main__.py
+++ b/javsp/__main__.py
@@ -241,6 +241,7 @@ def info_summary(movie: Movie, all_info: Dict[str, MovieInfo]):
         final_info.genre.append('内嵌字幕')
     if movie.uncensored:
         final_info.genre.append('无码流出/破解')
+        final_info.uncensored = True
 
     # 女优别名固定
     if Cfg().crawler.normalize_actress_name and bool(final_info.actress_pics):

--- a/javsp/datatype.py
+++ b/javsp/datatype.py
@@ -105,7 +105,13 @@ class MovieInfo:
         d['rawtitle'] = info.ori_title or d['title']
         d['actress'] = ','.join(info.actress) if info.actress else Cfg().summarizer.default.actress
         d['score'] = info.score or '0'
-        d['censor'] = Cfg().summarizer.censor_options_representation[1 if info.uncensored else 0]
+        # uncensored字段为True表示无码，False表示有码，None表示未知
+        # 对应 0:无码 1:有码 2:未知
+        d['censor'] = {
+            True: Cfg().summarizer.censor_options_representation[0],
+            False: Cfg().summarizer.censor_options_representation[1],
+            None: Cfg().summarizer.censor_options_representation[2]
+        }[info.uncensored]
         d['serial'] = info.serial or Cfg().summarizer.default.series
         d['director'] = info.director or Cfg().summarizer.default.director
         d['producer'] = info.producer or Cfg().summarizer.default.producer


### PR DESCRIPTION
根据配置文件中对censor_options_representation的备注以及原来对该字段的处理方案可知，现有逻辑会导致censor的取值与实际得到的值存在不一致。