### PR TITLE
修复 `cid` 与 `dvdid` 并存时错误模块名导致无法调用 normal crawlers 的问题

### DIFF
--- a/javsp/__main__.py
+++ b/javsp/__main__.py
@@ -120,7 +120,7 @@ def parallel_crawler(movie: Movie, tqdm_bar=None):
         for i in all_info.values():
             i.dvdid = None
         for i in Cfg().crawler.selection.normal:
-            all_info[i] = MovieInfo(movie.dvdid)
+            all_info[i.value] = MovieInfo(movie.dvdid)
     thread_pool = []
     for mod_partial, info in all_info.items():
         mod = f"javsp.web.{mod_partial}"


### PR DESCRIPTION
如题