### PR TITLE
修复 下载剧照失败时会导致整理失败，主程序退出

### DIFF
--- a/javsp/__main__.py
+++ b/javsp/__main__.py
@@ -502,10 +502,12 @@ def RunNormalMode(all_movies):
                                 elapsed = time.strftime("%M:%S", time.gmtime(info['elapsed']))
                                 speed = get_fmt_size(info['rate']) + '/s'
                                 logger.info(f"已下载剧照{pic_url} {id}.png: {width}x{height}, {filesize} [{elapsed}, {speed}]")
-                            else:
+                            else:                               
                                 check_step(False, f"下载剧照{id}: {pic_url}失败")
                         except:
-                            check_step(False, f"下载剧照{id}: {pic_url}失败")
+                            # 下载失败，不要在rasise exception，跳过，从而不打断整理
+                            logger.error(f"下载剧照{id}: {pic_url}失败")
+                            # check_step(False, f"下载剧照{id}: {pic_url}失败")
                         time.sleep(scrape_interval)
                 check_step(True)
 


### PR DESCRIPTION
当下载剧照失败时，程序已经获取了异常， 应该打印错误，跳过进行下一步，不用重新再抛出异常给外层， 会导致主程序退出， 整理失败。

<img width="517" alt="image" src="https://github.com/user-attachments/assets/44ec22cc-531b-4543-9965-dbe54595df2a" />
